### PR TITLE
Update systemd dependency

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -2,7 +2,7 @@
 
 roles:
   - name: jonaspammer.bootstrap
-  - name: 0x0i.systemd
+  - name: https://github.com/O1ahmad/ansible-role-systemd
 
 collections:
   - containers.podman

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,6 +2,7 @@
 
 roles:
   - name: jonaspammer.bootstrap
+  # @TODO: Use the galaxy uri again once a new release has been created
   - name: https://github.com/O1ahmad/ansible-role-systemd
 
 collections:

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,9 @@
 roles:
   - name: jonaspammer.bootstrap
   # @TODO: Use the galaxy uri again once a new release has been created
-  - name: https://github.com/O1ahmad/ansible-role-systemd
+  - src: https://github.com/O1ahmad/ansible-role-systemd
+    version: master
+    scm: git
 
 collections:
   - containers.podman


### PR DESCRIPTION
##### SUMMARY

here is a bug in the upstream role that was fixed that caused activiation of units to fail in check_mode. As no new release has been created since then, as a workaround, we use the git uri of the role as source.


 - Bugfix Pull Request