### PR TITLE
Fix rsync losing oversight over temporary files

### DIFF
--- a/templates/usr/local/bin/rsync_single_mirror.j2
+++ b/templates/usr/local/bin/rsync_single_mirror.j2
@@ -78,7 +78,7 @@ fi
 log-message 0 "Started $repo_name mirror rsync job."
 rsync --verbose --log-file="${log}" --no-motd --human-readable --recursive \
     --hard-links --links --safe-links --times --perms --chmod=u=rwX,go=rX \
-    --delete-after --delay-updates --temp-dir="${tmp_path}" \
+    --delete-during --delay-updates --temp-dir="${tmp_path}" \
     --bwlimit="${bwlimit}" --timeout="${rsync_timeout}" --contimeout=60 \
     "${repo_source}" \
     "${base_path}"

--- a/templates/usr/local/bin/rsync_single_mirror.j2
+++ b/templates/usr/local/bin/rsync_single_mirror.j2
@@ -78,7 +78,7 @@ fi
 log-message 0 "Started $repo_name mirror rsync job."
 rsync --verbose --log-file="${log}" --no-motd --human-readable --recursive \
     --hard-links --links --safe-links --times --perms --chmod=u=rwX,go=rX \
-    --delete-during --delay-updates --temp-dir="${tmp_path}" \
+    --delete-during --temp-dir="${tmp_path}" \
     --bwlimit="${bwlimit}" --timeout="${rsync_timeout}" --contimeout=60 \
     "${repo_source}" \
     "${base_path}"

--- a/templates/usr/local/bin/rsync_ubuntu_mirror.j2
+++ b/templates/usr/local/bin/rsync_ubuntu_mirror.j2
@@ -86,7 +86,7 @@ fi
 log-message 0 "Started stage 2 of $repo_name mirror rsync job."
 rsync --verbose --log-file="${log_file}" --no-motd --human-readable --recursive \
     --hard-links --links --safe-links --times --perms --chmod=u=rwX,go=rX \
-    --delete-after --temp-dir="${tmp_path}" \
+    --delete-during --temp-dir="${tmp_path}" \
     --bwlimit="${bwlimit}" --timeout=120 --contimeout=60 \
     "${repo_source}" \
     "${base_path}"


### PR DESCRIPTION
##### SUMMARY
For an issue description, see: https://github.com/adfinis/ansible-role-repo_mirror/issues/19

Basically, those folders are created by rsync due to the `--delete-after` call and if rsync crashes, those temporary files arent cleaned up.

In this MR, we switch to `--delete-during`, this generates a higher IO load, but ensures that there are no temporary files.

##### ISSUE TYPE
 - Bugfix Pull Request