### PR TITLE
Fix role metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ repo_mirror_repos: []
 
 ## Dependencies
 
-Please see the [meta/main.yml](https://github.com/adfinis/ansible-role-repo_mirror/blob/master/meta/main.yml) file for requirements for
-this role and the [molecule_requirements.yml](https://github.com/adfinis/ansible-role-repo_mirror/blob/master/molecule_requirements.yml) file for the
+The role requires the `master` version of this role: https://github.com/O1ahmad/ansible-role-systemd
+
+Please see the [molecule_requirements.yml](https://github.com/adfinis/ansible-role-repo_mirror/blob/master/molecule_requirements.yml) file for the
 molecule requirements.
 
 ## Example Playbook

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - mirror
     - rsync
     - wget
+  github_branch: master
 
 collections:
   - ansible.posix

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,9 +24,4 @@ collections:
   - community.general
   - adfinis.facts
 
-dependencies:
-  - name: robertdebock.bootstrap
-  # @TODO: Use the galaxy uri again once a new release has been created
-  - src: https://github.com/O1ahmad/ansible-role-systemd
-    version: master
-    scm: git
+dependencies: []


### PR DESCRIPTION
##### SUMMARY

This PR removes the dependency definition from the `meta/main.yml` as the file does not support git URIs as dependency source.
A hint in the README was added instead.

Also, a missing field was added that indicates the branch to be pushed.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request