### PR TITLE
(feat) add optional zfs dataset management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,14 @@ repo_mirror_rsync_timeout: 30
 # The default directory to clone the landingpage repository to
 repo_mirror_landingpage_clone_dir: /opt/landingpage
 
+# if to manage/modify/touch zfs datasets, default false
+repo_mirror_zfs_managed: false
+
+# zfs datasets to manage, default set to none
+repo_mirror_zfs_datasets:
+  - name: "pkg/debian"
+    quota: "1000G"
+
 # the default max runtime for a sync job
 _default_systemd_unit_max_runtime_sec: 43200  # 12 hours
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -6,6 +6,16 @@
 - name: Populate service facts
   ansible.builtin.service_facts:
 
+- name: create zfs datasets
+  community.general.zfs:
+    name: '{{ item.name }}'
+    state: present
+    extra_zfs_properties:
+      quota: '{{ item.quota }}'
+      mountpoint: '{{ repo_mirror_base_path }}/{{ item.name | split("/")[1] }}'
+  with_items: "{{ repo_mirror_zfs_datasets }}"
+  when: repo_mirror_zfs_datasets is defined and repo_mirror_zfs_managed is true
+
 - name: Create sync dirs
   ansible.builtin.file:
     path: "{{ repo_mirror_base_path }}/{{ item.name }}"


### PR DESCRIPTION
##### SUMMARY
This PR adds optional, disabled by default zfs dataset management as we use ZFS on our mirror.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
