### PR TITLE
(fix): ZFS human units

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -11,7 +11,7 @@
     name: '{{ item.name }}'
     state: present
     extra_zfs_properties:
-      quota: '{{ item.quota }}'
+      quota: '{{ item.quota | human_to_bytes(default_unit="G") }}'
       mountpoint: '{{ repo_mirror_base_path }}/{{ (item.name | split("/"))[1] }}'
   with_items: "{{ repo_mirror_zfs_datasets }}"
   when: repo_mirror_zfs_datasets is defined and repo_mirror_zfs_managed is true


### PR DESCRIPTION
##### SUMMARY
The ZFS module of ansible takes human-readable values of sizes and converts it to bytes.
This results in a "change" being made if the playbook is run, because the module will return bytes values.

Instead of providing bytes directly so no "change" is made, we allow the user to provide a human-readable value and convert it the bytes first.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request