### PR TITLE
(fix): let systemd kill processes correctly

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -103,7 +103,6 @@
               User: "{{ repo_mirror_user }}"
               Group: "{{ repo_mirror_group }}"
               ExecStart: "/usr/local/bin/mirror_{{ item.name }}.sh"
-              KillMode: process
               RuntimeMaxSec: "{{ item.systemd_unit_max_runtime_sec | default(_default_systemd_unit_max_runtime_sec) }}"
             state: "{{ item.systemd_service_unit_state | default(_default_systemd_service_unit_state) }}"
 


### PR DESCRIPTION
##### SUMMARY
This PR simply fixes systemd not being able to kill riunning rsync processes.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request