### PR TITLE
No quota management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,6 @@ repo_mirror_zfs_managed: false
 # zfs datasets to manage, default set to none
 repo_mirror_zfs_datasets:
   - name: "pkg/debian"
-    quota: "1000G"
 
 # the default max runtime for a sync job
 _default_systemd_unit_max_runtime_sec: 43200  # 12 hours

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -11,7 +11,6 @@
     name: '{{ item.name }}'
     state: present
     extra_zfs_properties:
-      quota: '{{ item.quota }}'
       mountpoint: '{{ repo_mirror_base_path }}/{{ (item.name | split("/"))[1] }}'
   with_items: "{{ repo_mirror_zfs_datasets }}"
   when: repo_mirror_zfs_datasets is defined and repo_mirror_zfs_managed is true


### PR DESCRIPTION
##### SUMMARY
For whatever reason i thought it would be cool to manage the quota using ansible.
This is, for the application of a continuously growing mirror, not really a good idea.

Therefore i removed the "feature" of quota management.

##### ISSUE TYPE
 - Bugfix Pull Request