### PR TITLE
fix: missing role dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,4 +24,5 @@ collections:
   - community.general
   - adfinis.facts
 
-dependencies: []
+dependencies:
+  - role: 0x0i.systemd


### PR DESCRIPTION
##### SUMMARY
This role makes use of the `0x01.systemd` role to configure systemd units. However, it was not added to the roles dependencies, so it wasn't automatically installed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request